### PR TITLE
feat: FooterにZennのアイコンとリンクを追加

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -6,6 +6,7 @@
 		"blinkmacsystemfont",
 		"Kaku",
 		"Qiita",
+		"Zenn",
 		"fontawesome",
 		"Fonticons",
 		"Redmine",

--- a/src/lib/component/Icons/IconZenn.svelte
+++ b/src/lib/component/Icons/IconZenn.svelte
@@ -1,0 +1,9 @@
+<script>
+	export let className = '';
+</script>
+
+<svg class={className} role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"
+	><title>Zenn</title><path
+		d="M.264 23.771h4.984c.264 0 .498-.147.645-.381L19.614.874c.176-.293-.029-.645-.381-.645h-4.72c-.264 0-.498.147-.645.381L.249 23.39c-.176.293.029.645.381.645l-.366-.264z"
+	/></svg
+>

--- a/src/lib/component/Icons/IconZenn.svelte
+++ b/src/lib/component/Icons/IconZenn.svelte
@@ -2,8 +2,27 @@
 	export let className = '';
 </script>
 
-<svg class={className} role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"
-	><title>Zenn</title><path
-		d="M.264 23.771h4.984c.264 0 .498-.147.645-.381L19.614.874c.176-.293-.029-.645-.381-.645h-4.72c-.264 0-.498.147-.645.381L.249 23.39c-.176.293.029.645.381.645l-.366-.264z"
-	/></svg
+<svg
+	class={className}
+	version="1.1"
+	xmlns="http://www.w3.org/2000/svg"
+	xmlns:xlink="http://www.w3.org/1999/xlink"
+	x="0px"
+	y="0px"
+	viewBox="0 0 88.3 88.3"
+	style="enable-background:new 0 0 88.3 88.3;"
+	xml:space="preserve"
 >
+	<g>
+		<path
+			class="st0"
+			d="M3.9,83.3h17c0.9,0,1.7-0.5,2.2-1.2L69.9,5.2c0.6-1-0.1-2.2-1.3-2.2H52.5c-0.8,0-1.5,0.4-1.9,1.1L3.1,81.9
+		C2.8,82.5,3.2,83.3,3.9,83.3z"
+		/>
+		<path
+			class="st0"
+			d="M62.5,82.1l22.1-35.5c0.7-1.1-0.1-2.5-1.4-2.5h-16c-0.6,0-1.2,0.3-1.5,0.8L43,81.2c-0.6,0.9,0.1,2.1,1.2,2.1
+		h16.3C61.3,83.3,62.1,82.9,62.5,82.1z"
+		/>
+	</g>
+</svg>

--- a/src/lib/component/SNS.svelte
+++ b/src/lib/component/SNS.svelte
@@ -4,6 +4,7 @@
 	import FaLinkedIn from './Icons/FaLinkedIn.svelte';
 	import FaXTwitter from './Icons/FaXTwitter.svelte';
 	import IconQiita from './Icons/IconQiita.svelte';
+	import IconZenn from './Icons/IconZenn.svelte';
 </script>
 
 <ul class="flex gap-x-4">
@@ -54,6 +55,17 @@
 			rel="noopener noreferrer"
 			aria-label="Qiitaリンク"
 			><IconQiita
+				className="fill-divider hover:fill-white h-6 dark:fill-lightBody dark:hover:fill-divider"
+			/></a
+		>
+	</li>
+	<li>
+		<a
+			href="https://zenn.dev/morimorig3"
+			target="_blank"
+			rel="noopener noreferrer"
+			aria-label="Zennリンク"
+			><IconZenn
 				className="fill-divider hover:fill-white h-6 dark:fill-lightBody dark:hover:fill-divider"
 			/></a
 		>


### PR DESCRIPTION
## Summary
- QiitaアイコンのすぐRight側にZennアイコンとリンクを追加
- ZennのSVGアイコンコンポーネント（IconZenn.svelte）を作成
- 既存のSNSコンポーネントに統合し、一貫したスタイリングを適用
- cspell辞書にZennを追加してスペルチェックエラーを解決

## Test plan
- [x] 全てのテストが通ることを確認
- [x] Lintエラーがないことを確認
- [x] フォーマットが正しいことを確認
- [x] スペルチェックが通ることを確認

Closes #59

🤖 Generated with [Claude Code](https://claude.ai/code)